### PR TITLE
[PLAT-910] Enable support for Ruby 2.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,40 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/)
 
+## 2.2.0 - 2022-5-16
+
+### Added
+
+Added unconfigured rules that have default `Enabled` values of `'pending'`:
+- Lint/RaiseException: enabled
+- Lint/StructNewOverride: enabled
+- Style/HashEachMethods: disabled
+- Style/HashTransformKeys: disabled
+- Style/HashTransformValues: disabled
+
+Disabled cops causing new failures in VBE, Authenticator, or Viceroy:
+- Naming/RescuedExceptionsVariableName
+- Layout/ArgumentAlignment
+- Style/FloatDivision
+- Lint/RedundantStringCoercion
+- Style/FormatStringToken
+- Style/RedundantReturn
+- Layout/SpaceInsideStringInterpolation
+- Style/RedundantParentheses
+- Layout/HashAlignment
+- Style/ExpandPathArguments
+- Layout/EmptyLineAfterGuardClause
+- Migration/DepartmentName
+
+### Fixed
+
+- Upgraded minimum rubocop to support ruby 2.7
+- Added rubocop-rails gem—-it was removed from the rubocop gem prior to the version we're updating to here
+- Updated outdated rules:
+  - Updated Layout/IndentArray to Layout/FirstArrayElementIndentation
+  - Updated Layout/AlignHash to Layout/HashAlignment
+  - Updated Metrics/LineLength to Layout/LineLength
+
 ## 2.1.0 - 2020-11-05
 
 ### Added

--- a/lib/snap/style/version.rb
+++ b/lib/snap/style/version.rb
@@ -1,5 +1,5 @@
 module Snap
   module Style
-    VERSION = '2.1.0'
+    VERSION = '2.2.0'
   end
 end

--- a/rubocop/rubocop.yml
+++ b/rubocop/rubocop.yml
@@ -7,6 +7,8 @@
 # e.g.: rubocop --auto-correct --only Style/HashSyntax
 #
 
+require: rubocop-rails
+
 Rails:
   Enabled: true
 
@@ -26,12 +28,8 @@ Layout/SpaceInsideReferenceBrackets:
 Layout/SpaceInsideArrayLiteralBrackets:
   Enabled: false
 
-Layout/IndentArray:
+Layout/FirstArrayElementIndentation:
   EnforcedStyle: 'consistent'
-
-Layout/AlignHash:
-  EnforcedColonStyle: 'key'
-  EnforcedHashRocketStyle: 'key'
 
 Style/Documentation:
   Enabled: false
@@ -54,7 +52,7 @@ Metrics/MethodLength:
 Metrics/BlockLength:
   Max: 100
 
-Metrics/LineLength:
+Layout/LineLength:
   Enabled: false
 
 Metrics/CyclomaticComplexity:
@@ -106,3 +104,68 @@ Metrics/ClassLength:
   Description: 'Avoid classes longer than 250 lines of code.'
   Enabled: false
   Max: 250
+
+# The following cops were added between 0.63.0 and 0.81.0
+# They have default default `Enabled` values of `'pending'`, so Rubopcop forces you to enable or disable them
+Lint/RaiseException:
+    Enabled: true
+
+Lint/StructNewOverride:
+    Enabled: true
+
+# These are marked as unsafe, in addition to `Enabled: 'pending'`
+Style/HashEachMethods:
+    Enabled: false
+
+Style/HashTransformKeys:
+    Enabled: false
+
+Style/HashTransformValues:
+    Enabled: false
+
+# The following cops cause new failures in VBE
+# They need to be reviewed before enabling
+
+Naming/RescuedExceptionsVariableName:
+  Enabled: false
+
+Layout/ArgumentAlignment:
+  Enabled: false
+
+Style/FloatDivision:
+  Enabled: false
+
+Lint/RedundantStringCoercion:
+  Enabled: false
+
+Style/FormatStringToken:
+  Enabled: false
+
+Style/RedundantReturn:
+  Enabled: false
+
+Layout/SpaceInsideStringInterpolation:
+  Enabled: false
+
+Style/RedundantParentheses:
+  Enabled: false
+
+# The following cops cause new failures in Viceroy
+# They need to be reviewed before enabling
+
+Layout/HashAlignment:
+  EnforcedColonStyle: 'key'
+  EnforcedHashRocketStyle: 'key'
+  Enabled: false
+
+Style/ExpandPathArguments:
+  Enabled: false
+
+Layout/EmptyLineAfterGuardClause:
+  Enabled: false
+
+# The following cops cause new failures in Authenticator
+# They need to be reviewed before enabling
+
+Migration/DepartmentName:
+  Enabled: false

--- a/snap-style.gemspec
+++ b/snap-style.gemspec
@@ -20,7 +20,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rubocop", "~> 0.63.0"
+  spec.add_dependency "rubocop", "~> 0.81.0"
+  spec.add_dependency "rubocop-rails", "~> 2.5.2"
 
   spec.add_development_dependency "bundler", "~> 1.17.3"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
We're updating Viceroy to Ruby 2.7.5, with which snap-style is not compatible. This PR is intended to enable that compatibility while maintaining compatibility with Ruby 2.3.

You should be able to test this by modifying the Gemfile of an integrating app to point to a local version of snap-style, like so:

![Screen Shot 2022-05-03 at 1 50 45 PM](https://user-images.githubusercontent.com/37208150/166510500-b44c2c49-95ec-4bb3-8a63-33fa0f4b3da4.png)

Then run `rubocop`. (The testing setup will be a bit more complex if you're using docker with the integrating app.)

I've tested this in VBE, Auth, and Viceroy. Here are the failing cops that, after discussion with Peter Langlois,  I've left enabled:

- `Lint/NonDeterministicRequireOrder`: This cop was added between version 0.63.0 and 0.81.0.
- `RedundantCopDisableDirective`: This cop was added between version 0.63.0 and 0.81.0.

For the time being, we've disabled other failing cops until the Backend Committee has reviewed them.