### PR TITLE
CRS-3338 Updating SnapStyle to support Cops for Ruby 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/)
 
-## 2.2.0 - 2022-5-16
+## 2.3.0 - 2022-10-07
+
+### Updated
+
+Relax dependency to `rubocop` to enable support for Ruby 3.
+
+## 2.2.0 - 2022-05-16
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,25 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/)
 
-## 2.3.0 - 2022-10-07
+## 3.0.0 - 2022-10-07
 
 ### Updated
 
 Relax dependency to `rubocop` to enable support for Ruby 3.
+
+Rubocop breaking changes:
+- 0.82.0: Renamed `Layout/Tab` cop to `Layout/IndentationStyle`.
+- 0.83.0: Inspect all files given on command line unless `--only-recognized-file-types` is given.
+- 0.83.0: Enabling a cop overrides disabling its department.
+- 0.84.0: Change the max line length of `Layout/LineLength` to 120 by default.
+- 0.85.0: Remove support for `unindent/active_support/powerpack` from `Layout/HeredocIndentation`, so it only recommends using squiggy heredoc.
+- 0.86.0: Cop `Metrics/CyclomaticComplexity` now counts &., ||=, &&= and blocks known to iterate. Default bumped from 6 to 7. Consider using `rubocop -a --disable-uncorrectable` to ease transition.
+- 0.87.0: Extensive refactoring of internal classes `Team`, `Commissioner`, `Corrector`. `Cop::Cop#corrections` not completely compatible.
+- 0.87.0: `rubocop -a / --auto-correct` no longer run unsafe corrections; `rubocop -A / --auto-correct-all` run both safe and unsafe corrections. Options `--safe-autocorrect` is deprecated.
+- 0.87.0: Order for gems names now disregards underscores and dashes unless `ConsiderPunctuation` setting is set to true.
+- 0.89.0: Cop `Metrics/AbcSize` now counts ||=, &&=, multiple assignments, for, yield, iterating blocks. &. now count as conditions too (unless repeated on the same variable). Default bumped from 15 to 17. Consider using `rubocop -a --disable-uncorrectable` to ease transition.
+- 0.89.0: Cop `Metrics/PerceivedComplexity` now counts else in case statements, &., ||=, &&= and blocks known to iterate. Default bumped from 7 to 8. Consider using `rubocop -a --disable-uncorrectable` to ease transition.
+
 
 ## 2.2.0 - 2022-05-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,17 +10,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/)
 Relax dependency to `rubocop` to enable support for Ruby 3.
 
 Rubocop breaking changes:
-- 0.82.0: Renamed `Layout/Tab` cop to `Layout/IndentationStyle`.
-- 0.83.0: Inspect all files given on command line unless `--only-recognized-file-types` is given.
-- 0.83.0: Enabling a cop overrides disabling its department.
-- 0.84.0: Change the max line length of `Layout/LineLength` to 120 by default.
-- 0.85.0: Remove support for `unindent/active_support/powerpack` from `Layout/HeredocIndentation`, so it only recommends using squiggy heredoc.
-- 0.86.0: Cop `Metrics/CyclomaticComplexity` now counts &., ||=, &&= and blocks known to iterate. Default bumped from 6 to 7. Consider using `rubocop -a --disable-uncorrectable` to ease transition.
-- 0.87.0: Extensive refactoring of internal classes `Team`, `Commissioner`, `Corrector`. `Cop::Cop#corrections` not completely compatible.
-- 0.87.0: `rubocop -a / --auto-correct` no longer run unsafe corrections; `rubocop -A / --auto-correct-all` run both safe and unsafe corrections. Options `--safe-autocorrect` is deprecated.
-- 0.87.0: Order for gems names now disregards underscores and dashes unless `ConsiderPunctuation` setting is set to true.
-- 0.89.0: Cop `Metrics/AbcSize` now counts ||=, &&=, multiple assignments, for, yield, iterating blocks. &. now count as conditions too (unless repeated on the same variable). Default bumped from 15 to 17. Consider using `rubocop -a --disable-uncorrectable` to ease transition.
-- 0.89.0: Cop `Metrics/PerceivedComplexity` now counts else in case statements, &., ||=, &&= and blocks known to iterate. Default bumped from 7 to 8. Consider using `rubocop -a --disable-uncorrectable` to ease transition.
+- [0.82.0](https://github.com/rubocop/rubocop/blob/v0.82.0/CHANGELOG.md): Renamed `Layout/Tab` cop to `Layout/IndentationStyle`.
+- [0.83.0](https://github.com/rubocop/rubocop/blob/v0.83.0/CHANGELOG.md): Inspect all files given on command line unless `--only-recognized-file-types` is given.
+- [0.83.0](https://github.com/rubocop/rubocop/blob/v0.83.0/CHANGELOG.md): Enabling a cop overrides disabling its department.
+- [0.84.0](https://github.com/rubocop/rubocop/blob/v0.84.0/CHANGELOG.md): Change the max line length of `Layout/LineLength` to 120 by default.
+- [0.85.0](https://github.com/rubocop/rubocop/blob/v0.85.0/CHANGELOG.md): Remove support for `unindent/active_support/powerpack` from `Layout/HeredocIndentation`, so it only recommends using squiggy heredoc.
+- [0.86.0](https://github.com/rubocop/rubocop/blob/v0.86.0/CHANGELOG.md): Cop `Metrics/CyclomaticComplexity` now counts &., ||=, &&= and blocks known to iterate. Default bumped from 6 to 7. Consider using `rubocop -a --disable-uncorrectable` to ease transition.
+- [0.87.0](https://github.com/rubocop/rubocop/blob/v0.87.0/CHANGELOG.md): Extensive refactoring of internal classes `Team`, `Commissioner`, `Corrector`. `Cop::Cop#corrections` not completely compatible.
+- [0.87.0](https://github.com/rubocop/rubocop/blob/v0.87.0/CHANGELOG.md): `rubocop -a / --auto-correct` no longer run unsafe corrections; `rubocop -A / --auto-correct-all` run both safe and unsafe corrections. Options `--safe-autocorrect` is deprecated.
+- [0.87.0](https://github.com/rubocop/rubocop/blob/v0.87.0/CHANGELOG.md): Order for gems names now disregards underscores and dashes unless `ConsiderPunctuation` setting is set to true.
+- [0.89.0](https://github.com/rubocop/rubocop/blob/v0.89.0/CHANGELOG.md): Cop `Metrics/AbcSize` now counts ||=, &&=, multiple assignments, for, yield, iterating blocks. &. now count as conditions too (unless repeated on the same variable). Default bumped from 15 to 17. Consider using `rubocop -a --disable-uncorrectable` to ease transition.
+- [0.89.0](https://github.com/rubocop/rubocop/blob/v0.89.0/CHANGELOG.md): Cop `Metrics/PerceivedComplexity` now counts else in case statements, &., ||=, &&= and blocks known to iterate. Default bumped from 7 to 8. Consider using `rubocop -a --disable-uncorrectable` to ease transition.
 
 
 ## 2.2.0 - 2022-05-16

--- a/lib/snap/style/version.rb
+++ b/lib/snap/style/version.rb
@@ -1,5 +1,5 @@
 module Snap
   module Style
-    VERSION = '2.3.0'
+    VERSION = '3.0.0'
   end
 end

--- a/lib/snap/style/version.rb
+++ b/lib/snap/style/version.rb
@@ -1,5 +1,5 @@
 module Snap
   module Style
-    VERSION = '2.2.0'
+    VERSION = '2.3.0'
   end
 end

--- a/snap-style.gemspec
+++ b/snap-style.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rubocop", "~> 0.81.0"
+  spec.add_dependency "rubocop", "~> 0.92.0"
   spec.add_dependency "rubocop-rails", "~> 2.5.2"
 
   spec.add_development_dependency "bundler", "~> 1.17.3"


### PR DESCRIPTION
Closes https://snapsheettech.atlassian.net/browse/CRS-3338

## What

`snap-style` isn't compatible with Ruby 3:

```
Error: RuboCop found unknown Ruby version 3.0 in `.ruby-version`.
Supported versions: 2.3, 2.4, 2.5, 2.6, 2.7
```

## Why

Version constraint defined on the `rubocop` dependency is too strict and doesn't allow more recent versions.

## How

Relax constraint to allow the use of a newer version supporting Ruby 3.