### PR TITLE
[PLAT-1264]: Upgrade snap-style Rubocop Version to 1.22.3+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,20 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/)
 
+## 4.0.0 - 2024-01-08
+
+### Updated
+
+Relax dependency to `rubocop` to enable support for Ruby 3.1.
+
+Rubocop breaking changes:
+- [0.93.0](https://github.com/rubocop/rubocop/releases/tag/v0.93.0): `RegexpNode#parsed_tree` now processes regexps including interpolation (by blanking the interpolation before parsing, rather than skipping).
+- [1.0.0](https://github.com/rubocop/rubocop/releases/tag/v1.0.0): RuboCop assumes that Cop classes do not define new `on_<type>` methods at runtime (e.g. via `extend` in `initialize`).
+- [1.0.0](https://github.com/rubocop/rubocop/releases/tag/v1.0.0): ~~Enable all pending cops for RuboCop 1.0~~. These have been disabled until further review.
+- [1.0.0](https://github.com/rubocop/rubocop/releases/tag/v1.0.0): Change logic for cop department name computation. Cops inside deep namespaces (5 or more levels deep) now belong to departments with names that are calculated by joining module names starting from the third one with slashes as separators. For example, cop `Rubocop::Cop::Foo::Bar::Baz` now belongs to `Foo/Bar` department (previously it was `Bar`).
+
+Disabled all new cops that are pending by default and all cops that were pending prior to Rubocop 1.0 until further review.
+
 ## 3.0.0 - 2022-10-07
 
 ### Updated

--- a/lib/snap/style/version.rb
+++ b/lib/snap/style/version.rb
@@ -1,5 +1,5 @@
 module Snap
   module Style
-    VERSION = '3.0.0'
+    VERSION = '4.0.0'
   end
 end

--- a/rubocop/rubocop.yml
+++ b/rubocop/rubocop.yml
@@ -170,7 +170,7 @@ Layout/EmptyLineAfterGuardClause:
 Migration/DepartmentName:
   Enabled: false
 
-# The following cops were added between 0.92.0 and 1.14.0
+# The following cops were added (or enabled) between 0.92.0 and 1.14.0
 Gemspec/DateAssignment: # new in 1.10
   Enabled: false
 Layout/LineEndStringConcatenationIndentation: # new in 1.18

--- a/rubocop/rubocop.yml
+++ b/rubocop/rubocop.yml
@@ -169,3 +169,186 @@ Layout/EmptyLineAfterGuardClause:
 
 Migration/DepartmentName:
   Enabled: false
+
+# The following cops were added between 0.92.0 and 1.14.0
+Gemspec/DateAssignment: # new in 1.10
+  Enabled: false
+Layout/LineEndStringConcatenationIndentation: # new in 1.18
+  Enabled: false
+Layout/SpaceBeforeBrackets: # new in 1.7
+  Enabled: false
+Lint/AmbiguousAssignment: # new in 1.7
+  Enabled: false
+Lint/AmbiguousOperatorPrecedence: # new in 1.21
+  Enabled: false
+Lint/AmbiguousRange: # new in 1.19
+  Enabled: false
+Lint/DeprecatedConstants: # new in 1.8
+  Enabled: false
+Lint/DuplicateBranch: # new in 1.3
+  Enabled: false
+Lint/DuplicateRegexpCharacterClassElement: # new in 1.1
+  Enabled: false
+Lint/EmptyBlock: # new in 1.1
+  Enabled: false
+Lint/EmptyClass: # new in 1.3
+  Enabled: false
+Lint/EmptyInPattern: # new in 1.16
+  Enabled: false
+Lint/IncompatibleIoSelectWithFiberScheduler: # new in 1.21
+  Enabled: false
+Lint/LambdaWithoutLiteralBlock: # new in 1.8
+  Enabled: false
+Lint/NoReturnInBeginEndBlocks: # new in 1.2
+  Enabled: false
+Lint/NumberedParameterAssignment: # new in 1.9
+  Enabled: false
+Lint/OrAssignmentToConstant: # new in 1.9
+  Enabled: false
+Lint/RedundantDirGlobSort: # new in 1.8
+  Enabled: false
+Lint/RequireRelativeSelfPath: # new in 1.22
+  Enabled: false
+Lint/SymbolConversion: # new in 1.9
+  Enabled: false
+Lint/ToEnumArguments: # new in 1.1
+  Enabled: false
+Lint/TripleQuotes: # new in 1.9
+  Enabled: false
+Lint/UnexpectedBlockArity: # new in 1.5
+  Enabled: false
+Lint/UnmodifiedReduceAccumulator: # new in 1.1
+  Enabled: false
+Security/IoMethods: # new in 1.22
+  Enabled: false
+Style/ArgumentsForwarding: # new in 1.1
+  Enabled: false
+Style/CollectionCompact: # new in 1.2
+  Enabled: false
+Style/DocumentDynamicEvalDefinition: # new in 1.1
+  Enabled: false
+Style/EndlessMethod: # new in 1.8
+  Enabled: false
+Style/HashConversion: # new in 1.10
+  Enabled: false
+Style/HashExcept: # new in 1.7
+  Enabled: false
+Style/IfWithBooleanLiteralBranches: # new in 1.9
+  Enabled: false
+Style/InPatternThen: # new in 1.16
+  Enabled: false
+Style/MultilineInPatternThen: # new in 1.16
+  Enabled: false
+Style/NegatedIfElseCondition: # new in 1.2
+  Enabled: false
+Style/NilLambda: # new in 1.3
+  Enabled: false
+Style/NumberedParameters: # new in 1.22
+  Enabled: false
+Style/NumberedParametersLimit: # new in 1.22
+  Enabled: false
+Style/QuotedSymbols: # new in 1.16
+  Enabled: false
+Style/RedundantArgument: # new in 1.4
+  Enabled: false
+Style/RedundantSelfAssignmentBranch: # new in 1.19
+  Enabled: false
+Style/SelectByRegexp: # new in 1.22
+  Enabled: false
+Style/StringChars: # new in 1.12
+  Enabled: false
+Style/SwapValues: # new in 1.1
+  Enabled: false
+Layout/BeginEndAlignment: # (new in 0.91)
+  Enabled: false
+Layout/EmptyLinesAroundAttributeAccessor: # (new in 0.83)
+  Enabled: false
+Layout/SpaceAroundMethodCallOperator: # (new in 0.82)
+  Enabled: false
+Lint/BinaryOperatorWithIdenticalOperands: # (new in 0.89)
+  Enabled: false
+Lint/ConstantDefinitionInBlock: # (new in 0.91)
+  Enabled: false
+Lint/DeprecatedOpenSSLConstant: # (new in 0.84)
+  Enabled: false
+Lint/DuplicateElsifCondition: # (new in 0.88)
+  Enabled: false
+Lint/DuplicateRequire: # (new in 0.90)
+  Enabled: false
+Lint/DuplicateRescueException: # (new in 0.89)
+  Enabled: false
+Lint/EmptyConditionalBody: # (new in 0.89)
+  Enabled: false
+Lint/EmptyFile: # (new in 0.90)
+  Enabled: false
+Lint/FloatComparison: # (new in 0.89)
+  Enabled: false
+Lint/HashCompareByIdentity: # (new in 0.93)
+  Enabled: false
+Lint/IdentityComparison: # (new in 0.91)
+  Enabled: false
+Lint/MissingSuper: # (new in 0.89)
+  Enabled: false
+Lint/MixedRegexpCaptureTypes: # (new in 0.85)
+  Enabled: false
+Lint/OutOfRangeRegexpRef: # (new in 0.89)
+  Enabled: false
+Lint/RedundantSafeNavigation: # (new in 0.93)
+  Enabled: false
+Lint/SelfAssignment: # (new in 0.89)
+  Enabled: false
+Lint/TopLevelReturnWithArgument: # (new in 0.89)
+  Enabled: false
+Lint/TrailingCommaInAttributeDeclaration: # (new in 0.90)
+  Enabled: false
+Lint/UnreachableLoop: # (new in 0.89)
+  Enabled: false
+Lint/UselessMethodDefinition: # (new in 0.90)
+  Enabled: false
+Lint/UselessTimes: # (new in 0.91)
+  Enabled: false
+Style/AccessorGrouping: # (new in 0.87)
+  Enabled: false
+Style/BisectedAttrAccessor: # (new in 0.87)
+  Enabled: false
+Style/CaseLikeIf: # (new in 0.88)
+  Enabled: false
+Style/ClassEqualityComparison: # (new in 0.93)
+  Enabled: false
+Style/CombinableLoops: # (new in 0.90)
+  Enabled: false
+Style/ExplicitBlockArgument: # (new in 0.89)
+  Enabled: false
+Style/ExponentialNotation: # (new in 0.82)
+  Enabled: false
+Style/GlobalStdStream: # (new in 0.89)
+  Enabled: false
+Style/HashAsLastArrayItem: # (new in 0.88)
+  Enabled: false
+Style/HashLikeCase: # (new in 0.88)
+  Enabled: false
+Style/KeywordParametersOrder: # (new in 0.90)
+  Enabled: false
+Style/OptionalBooleanParameter: # (new in 0.89)
+  Enabled: false
+Style/RedundantAssignment: # (new in 0.87)
+  Enabled: false
+Style/RedundantFetchBlock: # (new in 0.86)
+  Enabled: false
+Style/RedundantFileExtensionInRequire: # (new in 0.88)
+  Enabled: false
+Style/RedundantRegexpCharacterClass: # (new in 0.85)
+  Enabled: false
+Style/RedundantRegexpEscape: # (new in 0.85)
+  Enabled: false
+Style/RedundantSelfAssignment: # (new in 0.90)
+  Enabled: false
+Style/SingleArgumentDig: # (new in 0.89)
+  Enabled: false
+Style/SlicingWithRange: # (new in 0.83)
+  Enabled: false
+Style/SoleNestedConditional: # (new in 0.89)
+  Enabled: false
+Style/StringConcatenation: # (new in 0.89)
+  Enabled: false
+

--- a/snap-style.gemspec
+++ b/snap-style.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rubocop", "~> 0.92.0"
+  spec.add_dependency "rubocop", "~> 1.22.0"
   spec.add_dependency "rubocop-rails", "~> 2.5.2"
 
   spec.add_development_dependency "bundler", "~> 1.17.3"

--- a/snap-style.gemspec
+++ b/snap-style.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rubocop", "~> 1.22.0"
+  spec.add_dependency "rubocop", "~> 1.22.3"
   spec.add_dependency "rubocop-rails", "~> 2.5.2"
 
   spec.add_development_dependency "bundler", "~> 1.17.3"


### PR DESCRIPTION
## What

Closes https://snapsheettech.atlassian.net/browse/PLAT-1264 by upgrading Rubocop to 1.22.3. 

`snap-style` isn't compatible with Ruby 3.1:

```
Error: RuboCop found unknown Ruby version 3.1 in `.ruby-version`.
Supported versions: 2.3, 2.4, 2.5, 2.6, 2.7, 3.0
```

## Why

Version constraint defined on the `rubocop` dependency is too strict and doesn't allow more recent versions. 1.14 is compatible with Ruby 3.1, but that introduced [an issue](https://github.com/rubocop/rubocop/issues/10258) that isn't fixed until 1.22.3.

## How

Relax constraint to allow the use of a newer version supporting Ruby 3.1.
