### PR TITLE
Rubocop/v1.26: Update rubocop version to support for ruby 3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/)
 
+## 5.0.0 - 2024-10-07
+
+Relax dependency to `rubocop` to enable support for Ruby 3.2
+
+No breaking changes were introduced till this version.
+
 ## 4.0.0 - 2023-01-05
 
 Relax dependency to `rubocop` to enable support for Ruby 3.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/)
 
 Relax dependency to `rubocop` to enable support for Ruby 3.2
 
-No breaking changes were introduced till this version.
+No breaking changes were introduced until this version.
 
 ## 4.0.0 - 2023-01-05
 

--- a/lib/snap/style/version.rb
+++ b/lib/snap/style/version.rb
@@ -1,5 +1,5 @@
 module Snap
   module Style
-    VERSION = '4.0.0'
+    VERSION = '5.0.0'
   end
 end

--- a/snap-style.gemspec
+++ b/snap-style.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rubocop", "~> 1.22.3"
+  spec.add_dependency "rubocop", "~> 1.26"
   spec.add_dependency "rubocop-rails", "~> 2.5.2"
 
   spec.add_development_dependency "bundler", "~> 1.17.3"


### PR DESCRIPTION
## What

`snap-style` isn't compatible with Ruby 3.2:

```
Error: RuboCop found unknown Ruby version 3.2 in `.ruby-version`.
```

## Why
Version constraint defined on the `robocop` dependency is too strict and doesn't allow more recent versions.

I have to disable the following rules in dispatch to make zero changes.
<details>
<summary>New Rules</summary>
<pre>
Style/OpenStructUse:
  Enabled: false

Style/FetchEnvVar:
  Enabled: false

Style/ReturnNilInPredicateMethodDefinition:
  Enabled: false

Style/RedundantRegexpArgument:
  Enabled: false

Style/RedundantCurrentDirectoryInPath:
  Enabled: false

Style/ZeroLengthPredicate:
    Enabled: false

Style/HashSyntax:
  EnforcedStyle: 'ruby19'
  Enabled: false

Style/RedundantFilterChain:
  Enabled: false

Style/RedundantArrayConstructor:
  Enabled: false

Style/SuperArguments:
  Enabled: false

Style/ArgumentsForwarding:
  Enabled: false

Style/SafeNavigation:
  Enabled: false

Style/Next:
  Enabled: false

Style/RedundantSelfAssignmentBranch:
  Enabled: false

Style/ArrayIntersect:
  Enabled: false

Style/MapToHash:
  Enabled: false

Style/MapIntoArray:
  Enabled: false

Style/RedundantConstantBase:
  Enabled: false

Layout/MultilineMethodCallIndentation:
  Enabled: false

Layout/LineContinuationSpacing:
  Enabled: false

Layout/ExtraSpacing:
  Enabled: false

Layout/LineContinuationLeadingSpace:
  Enabled: false

Layout/EmptyLinesAroundExceptionHandlingKeywords:
  Enabled: false

Lint/RedundantCopDisableDirective:
  Enabled: false

Lint/RedundantWithIndex:
  Enabled: false
</pre>
</details>

## How
Relax constraints to allow the use of a newer version supporting Ruby 3.2.